### PR TITLE
Classes reformuladas e adição de teste unitário

### DIFF
--- a/crawler/domain.py
+++ b/crawler/domain.py
@@ -19,7 +19,7 @@ class Domain:
     def accessed_now(self) -> None:
         self.__accessible = False
         self.time_last_access = datetime.now()
-        Timer(interval=1.1 * self.int_time_limit_seconds, function=self.__turn_server_accessible).start()
+        Timer(interval=self.int_time_limit_seconds, function=self.__turn_server_accessible).start()
 
     def is_accessible(self) -> bool:
         return self.__accessible

--- a/crawler/domain.py
+++ b/crawler/domain.py
@@ -19,7 +19,7 @@ class Domain:
     def accessed_now(self) -> None:
         self.__accessible = False
         self.time_last_access = datetime.now()
-        Timer(interval=self.int_time_limit_seconds, function=self.__turn_server_accessible).start()
+        Timer(interval=1.1 * self.int_time_limit_seconds, function=self.__turn_server_accessible).start()
 
     def is_accessible(self) -> bool:
         return self.__accessible

--- a/crawler/page_fetcher.py
+++ b/crawler/page_fetcher.py
@@ -47,13 +47,15 @@ class PageFetcher(Thread):
             Coleta uma nova URL, obtendo-a do escalonador
         """
         url, depth = self.obj_scheduler.get_next_url()
+        cont = 0
         if url is not None:
             response = self.request_url(url)
             if response is not None:
                 for url, depth in self.discover_links(url, depth, response):
                     if url is not None:
+                        cont += 1
                         self.obj_scheduler.count_fetched_page()
-                        print(f'URL: {url.geturl()}')
+                        print(f'URL[{cont}]: {url.geturl()}')
 
     def run(self):
         """

--- a/crawler/scheduler.py
+++ b/crawler/scheduler.py
@@ -93,13 +93,13 @@ class Scheduler:
                 if len(self.dic_url_per_domain[domain]) > 0:
                     self.__acess_domain(domain)
                     return self.dic_url_per_domain[domain].pop(0)
+        sleep(Scheduler.TIME_LIMIT_BETWEEN_REQUESTS)
         return None, None
 
     def __acess_domain(self, domain):
         value = self.dic_url_per_domain[domain]
         domain.accessed_now()
         self.dic_url_per_domain[domain] = value
-        sleep(Scheduler.TIME_LIMIT_BETWEEN_REQUESTS)
 
     def can_fetch_page(self, obj_url) -> bool:
         """

--- a/crawler/scheduler.py
+++ b/crawler/scheduler.py
@@ -53,7 +53,14 @@ class Scheduler:
             e a url não foi descoberta ainda
         """
         domain = Domain(obj_url.hostname, Scheduler.TIME_LIMIT_BETWEEN_REQUESTS)
-        return self.int_depth_limit > depth and not (domain in self.dic_url_per_domain)
+        try:
+            value = self.dic_url_per_domain[domain]
+        except KeyError:
+            pass
+        else:
+            if (obj_url, depth) in value:
+                return False
+        return self.int_depth_limit > depth
 
     @synchronized
     def add_new_page(self, obj_url: ParseResult, depth: int) -> bool:
@@ -76,16 +83,23 @@ class Scheduler:
     @synchronized
     def get_next_url(self) -> tuple:
         """
-        Obtem uma nova URL por meio da fila. Essa URL é removida da fila.
+        Obtém uma nova URL por meio da fila. Essa URL é removida da fila.
         Logo após, caso o servidor não tenha mais URLs, o mesmo também é removido.
         """
-        for key in self.dic_url_per_domain.keys():
-            if key.is_accessible():
-                domain = self.dic_url_per_domain[key]
-                if len(domain) > 0:
-                    return domain.pop(0)
-        sleep(Scheduler.TIME_LIMIT_BETWEEN_REQUESTS)
+        for domain in self.dic_url_per_domain.keys():
+            if domain.is_accessible():
+                # Não extraia self.dic_url_per_domain[domain] para uma variável, pois essas modificações devem ser
+                # feitas por referência
+                if len(self.dic_url_per_domain[domain]) > 0:
+                    self.__acess_domain(domain)
+                    return self.dic_url_per_domain[domain].pop(0)
         return None, None
+
+    def __acess_domain(self, domain):
+        value = self.dic_url_per_domain[domain]
+        domain.accessed_now()
+        self.dic_url_per_domain[domain] = value
+        sleep(Scheduler.TIME_LIMIT_BETWEEN_REQUESTS)
 
     def can_fetch_page(self, obj_url) -> bool:
         """

--- a/crawler/scheduler_test.py
+++ b/crawler/scheduler_test.py
@@ -1,6 +1,6 @@
-import unittest
-from urllib.parse import urlparse
 import time
+import unittest
+
 from .domain import *
 from .scheduler import *
 
@@ -23,12 +23,23 @@ class DomainTest(unittest.TestCase):
 
 
 class SchedulerTest(unittest.TestCase):
+    urlXpto = (urlparse("http://www.xpto.com.br/index.html"), 100000)
+    urlTerra = (urlparse("http://www.terra.com.br/index.html"), 1)
+    urlTerra2 = (urlparse("http://www.terra.com.br/index.html"), 1)
+    urlTerraRep = (urlparse("http://www.terra.com.br/index.html"), 1)
+    urlUOL1 = (urlparse("http://www.uol.com.br/"), 1)
+    urlUOL2 = (urlparse("http://www.uol.com.br/profMax.html"), 1)
+    urlGlobo = (urlparse("http://www.globo.com.br/profMax.html"), 1)
+    MOCK_USER_AGENT = 'azulaoBot'
+    TIME_LIMIT = 10
+    DEPTH_LIMIT = 3
+    SEEDS = []
+
     def setUp(self):
-        arr_urls_seeds = []
         self.scheduler = Scheduler(str_usr_agent="xxbot",
-                                   int_page_limit=10,
-                                   int_depth_limit=3,
-                                   arr_urls_seeds=arr_urls_seeds)
+                                   int_page_limit=self.TIME_LIMIT,
+                                   int_depth_limit=self.DEPTH_LIMIT,
+                                   arr_urls_seeds=self.SEEDS)
 
     def test_init(self):
         arr_str_urls_seeds = ["cnn.com",
@@ -36,16 +47,39 @@ class SchedulerTest(unittest.TestCase):
         arr_urls_seeds = [urlparse(str_url) for str_url in arr_str_urls_seeds]
         self.assertEqual(3, 3, "Nao foi adicionado as sementes solicitadas")
 
-    def test_add_remove_page(self):
-        # tuplas url,profundidade a serem testadas
-        urlProf = (urlparse("http://www.xpto.com.br/index.html"), 100000)
-        urlTerra = (urlparse("http://www.terra.com.br/index.html"), 1)
-        urlTerraRep = (urlparse("http://www.terra.com.br/index.html"), 1)
-        urlUOL1 = (urlparse("http://www.uol.com.br/"), 1)
-        urlUOL2 = (urlparse("http://www.uol.com.br/profMax.html"), 1)
-        urlGlobo = (urlparse("http://www.globo.com.br/profMax.html"), 1)
+    def test_can_add_page(self):
+        self.__testCanAddPageWithLongTimeLimit()
+        self.__test_existed_domain()
 
-        arr_urls = [urlProf, urlTerra, urlTerraRep, urlUOL1, urlUOL2, urlGlobo]
+    def __testCanAddPageWithLongTimeLimit(self):
+        if Scheduler.TIME_LIMIT_BETWEEN_REQUESTS < self.urlXpto[1]:
+            canAddXpto = self.scheduler.can_add_page(*self.urlXpto)
+            self.assertFalse(canAddXpto, msg='A url XPTO não deveria poder ser adicionada')
+
+    def __test_existed_domain(self):
+        scheduler_test = Scheduler(str_usr_agent=self.MOCK_USER_AGENT,
+                                   int_page_limit=self.TIME_LIMIT,
+                                   int_depth_limit=self.DEPTH_LIMIT,
+                                   arr_urls_seeds=self.SEEDS)
+        self.__test_can_add_uol1(scheduler_test)
+        self.__add_uol_1(scheduler_test)
+        self.__test_can_add_uol2(scheduler_test)
+
+    def __add_uol_1(self, scheduler_test):
+        domainUol1 = Domain(self.urlUOL1[0].hostname, Scheduler.TIME_LIMIT_BETWEEN_REQUESTS)
+        scheduler_test.dic_url_per_domain[domainUol1] = [self.urlUOL1]
+
+    def __test_can_add_uol1(self, scheduler_test):
+        self.assertTrue(scheduler_test.can_add_page(*self.urlUOL1), msg='A URL do UOL1 deveria poder ser adicionada')
+
+    def __test_can_add_uol2(self, scheduler_test):
+        self.assertTrue(scheduler_test.can_add_page(*self.urlUOL2), msg='A URL do UOL2 deveria poder ser adicionada')
+
+    def test_add_remove_page(self):
+        self.test_can_add_page()
+        # tuplas url,profundidade a serem testadas
+
+        arr_urls = [self.urlXpto, self.urlTerra, self.urlTerraRep, self.urlUOL1, self.urlUOL2, self.urlGlobo]
 
         # adiciona todas as paginas em ordem
         # "**" faz passar a url e a profundidade
@@ -61,11 +95,11 @@ class SchedulerTest(unittest.TestCase):
         u1 = self.scheduler.get_next_url()
         u2 = self.scheduler.get_next_url()
         u3 = self.scheduler.get_next_url()
-        # ao obter a UOL, é considerado a primeira requição nela
+        # ao obter a UOL, é considerado a primeira requisição nela
         time_first_hit_UOL = datetime.now()
 
         print("Verificação da ordem das URLs...")
-        arr_expected_order = [urlTerra[0], urlUOL1[0], urlGlobo[0]]
+        arr_expected_order = [self.urlTerra[0], self.urlUOL1[0], self.urlGlobo[0]]
         arr_url_order = [u1[0], u2[0], u3[0]]
         for i, expected_url in enumerate(arr_expected_order):
             self.assertTrue(


### PR DESCRIPTION
## Qual o Problema Inicial?
- O antigo método `can_add_page` passava nos testes unitários mesmo considerando a repetição de domínio em vez da url;
- O método `get_next_url` não marcava o domínio como acessado.

## Oque esse PR faz?
- Corrige os problemas iniciais
- Cria um teste unitário para o método `can_add_page`

## Como testar?
Rodar todos os testes unitários para garantir que está tudo safe